### PR TITLE
Fixed CATTLE_URL env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The application, expects to get the following environment variables from the hos
 
 * CATTLE_ACCESS_KEY
 * CATTLE_SECRET_KEY
-* CATTLE_CONFIG_URL
+* CATTLE_URL
 
 ## Install and deploy
 

--- a/app.js
+++ b/app.js
@@ -20,14 +20,15 @@ function getOptions() {
         // required
         cattle_access_key:  process.env.CATTLE_ACCESS_KEY,
         cattle_secret_key:  process.env.CATTLE_SECRET_KEY,
+        cattle_config_url:  process.env.CATTLE_URL, 
 
         // optional
-        cattle_config_url:  process.env.CATTLE_CONFIG_URL || 'http://localhost:8080/v1',
         listen_port:        process.env.LISTEN_PORT || 9010,
         update_interval:    process.env.UPDATE_INTERVAL || 5000
     }
 
     var requiredOpts = [
+        'CATTLE_URL',
         'CATTLE_ACCESS_KEY',
         'CATTLE_SECRET_KEY'
     ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prometheus-rancher-exporter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Exposes Rancher metrics to Prometheus",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
As described here http://docs.rancher.com/rancher/v1.0/en/rancher-services/service-accounts/
Rancher will set environment variable CATTLE_URL and not CATTLE_CONFIG_URL, at least in the latest stable version (1.1.3).
In addition it won't work properly if not set, so defaulting to localhost if the variable is not set doesn't seem a good idea. Better make it mandatory, Rancher set it up automatically anyway

Updated the readme accordingly