### PR TITLE
Expose port 9173 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM gliderlabs/alpine
 MAINTAINER infinityworksltd
 
-EXPOSE 9110
+EXPOSE 9173
 
 RUN addgroup exporter \
  && adduser -S -G exporter exporter

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ If you find any issues, bug reports or PR's are more than welcome.
 
 Run manually from Docker Hub:
 ```
-docker run -d -e CATTLE_ACCESS_KEY="XXXXXXXX" -e CATTLE_SECRET_KEY="XXXXXXX" -e CATTLE_URL="http://<YOUR_IP>:8080/v2-beta" -p 9010:9010 infinityworks/prometheus-rancher-exporter
+docker run -d -e CATTLE_ACCESS_KEY="XXXXXXXX" -e CATTLE_SECRET_KEY="XXXXXXX" -e CATTLE_URL="http://<YOUR_IP>:8080/v2-beta" -p 9173:9173 infinityworks/prometheus-rancher-exporter
 ```
 
 Build a docker image:
 ```
 docker build -t <image-name> .
-docker run -d -e CATTLE_ACCESS_KEY="XXXXXXXX" -e CATTLE_SECRET_KEY="XXXXXXX" -e CATTLE_URL="http://<YOUR_IP>:8080/v2-beta" -p 9010:9010 <image-name>
+docker run -d -e CATTLE_ACCESS_KEY="XXXXXXXX" -e CATTLE_SECRET_KEY="XXXXXXX" -e CATTLE_URL="http://<YOUR_IP>:8080/v2-beta" -p 9173:9173 <image-name>
 ```
 
 ## Docker compose
@@ -54,7 +54,7 @@ prometheus-rancher-exporter:
       io.rancher.container.create_agent: true
       io.rancher.container.agent.role: environment
     expose:
-      - 9010:9010
+      - 9173:9173
     image: infinityworks/prometheus-rancher-exporter:latest
 ```
 
@@ -69,14 +69,14 @@ prometheus-rancher-exporter:
       - CATTLE_URL="http://<YOUR_IP>:8080/v2-beta"
       - HIDE_SYS=true
     expose:
-      - 9010:9010
+      - 9173:9173
     image: infinityworks/prometheus-rancher-exporter:latest
 ```
 
 
 ## Metrics
 
-Metrics will be made available on port 9010 by default, or you can pass environment variable ```LISTEN_ADDRESS``` to override this.
+Metrics will be made available on port 9173 by default, or you can pass environment variable ```LISTEN_ADDRESS``` to override this.
 An example printout of the metrics you should expect to see can be found in `METRICS.md`.
 
 

--- a/rancher_exporter.go
+++ b/rancher_exporter.go
@@ -29,7 +29,7 @@ func getenv(key, fallback string) string {
 
 var (
 	metricsPath   = getenv("METRICS_PATH", "/metrics") // Path under which to expose metrics.
-	listenAddress = getenv("LISTEN_ADDRESS", ":9010")  // Address on which to expose metrics.
+	listenAddress = getenv("LISTEN_ADDRESS", ":9173")  // Address on which to expose metrics.
 	rancherURL    = os.Getenv("CATTLE_URL")            // URL of Rancher Server API e.g. http://192.168.0.1:8080/v2-beta
 	accessKey     = os.Getenv("CATTLE_ACCESS_KEY")     // Optional - Access Key for Rancher API
 	secretKey     = os.Getenv("CATTLE_SECRET_KEY")     // Optional - Secret Key for Rancher API


### PR DESCRIPTION
The exporter listens on 9010, but the image exposes 9110. I think this was a typo introduced [recently](cc6af4e3b920c273164ed1d31e2eac0e73a7bd54).