### PR TITLE
Add support for Host agent state.

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -25,6 +25,7 @@ type Data struct {
 		EnvID       string `json:"environmentId"`
 		BaseType    string `json:"basetype"`
 		Type        string `json:"type"`
+		AgentState  string `json:"agentState"`
 	} `json:"data"`
 }
 
@@ -55,9 +56,9 @@ func (e *Exporter) processMetrics(data *Data, endpoint string, hideSys bool, ch 
 
 		if endpoint == "hosts" {
 
-			if err := e.setHostMetrics(x.HostName, x.State); err != nil {
+			if err := e.setHostMetrics(x.HostName, x.State, x.AgentState); err != nil {
 				log.Errorf("Error processing host metrics: %s", err)
-				log.Errorf("Attempt Failed to set %s, %s ", x.HostName, x.State)
+				log.Errorf("Attempt Failed to set %s, %s, [agent] %s ", x.HostName, x.State, x.AgentState)
 
 				continue
 			}

--- a/metrics.go
+++ b/metrics.go
@@ -53,6 +53,12 @@ func addMetrics() map[string]*prometheus.GaugeVec {
 			Name:      ("host_state"),
 			Help:      "State of defined host as reported by the Rancher API",
 		}, []string{"name", "state"})
+	gaugeVecs["hostAgentsState"] = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "rancher",
+			Name:      ("host_agent_state"),
+			Help:      "State of defined host agent as reported by the Rancher API",
+		}, []string{"name", "state"})
 
 	return gaugeVecs
 }
@@ -124,13 +130,21 @@ func (e *Exporter) setStackMetrics(name string, state string, health string) err
 }
 
 // setHostMetrics - Logic to set the state of a system as a gauge metric
-func (e *Exporter) setHostMetrics(name string, state string) error {
+func (e *Exporter) setHostMetrics(name string, state, agentState string) error {
 
 	for _, y := range hostStates {
 		if state == y {
 			e.gaugeVecs["hostsState"].With(prometheus.Labels{"name": name, "state": y}).Set(1)
 		} else {
 			e.gaugeVecs["hostsState"].With(prometheus.Labels{"name": name, "state": y}).Set(0)
+		}
+
+	}
+	for _, y := range agentStates {
+		if agentState == y {
+			e.gaugeVecs["hostAgentsState"].With(prometheus.Labels{"name": name, "state": y}).Set(1)
+		} else {
+			e.gaugeVecs["hostAgentsState"].With(prometheus.Labels{"name": name, "state": y}).Set(0)
 		}
 
 	}

--- a/rancher_exporter.go
+++ b/rancher_exporter.go
@@ -30,6 +30,7 @@ var (
 
 // Predefined variables that are used throughout the exporter
 var (
+	agentStates   = []string{"activating", "active", "reconnecting", "disconnected", "disconnecting", "finishing-reconnect", "reconnected"}
 	hostStates    = []string{"activating", "active", "deactivating", "error", "erroring", "inactive", "provisioned", "purged", "purging", "registering", "removed", "removing", "requested", "restoring", "updating_active", "updating_inactive"}
 	stackStates   = []string{"activating", "active", "canceled_upgrade", "canceling_upgrade", "error", "erroring", "finishing_upgrade", "removed", "removing", "requested", "restarting", "rolling_back", "updating_active", "upgraded", "upgrading"}
 	serviceStates = []string{"activating", "active", "canceled_upgrade", "canceling_upgrade", "deactivating", "finishing_upgrade", "inactive", "registering", "removed", "removing", "requested", "restarting", "rolling_back", "updating_active", "updating_inactive", "upgraded", "upgrading"}


### PR DESCRIPTION
The agent state is what is set when a host connects/disconnects from the
Rancher server.

Currently if a host is in the "reconnecting" state per the Rancher UI, this is not exposed via the metrics.