### PR TITLE
Add system label for stack metrics

### DIFF
--- a/gather.go
+++ b/gather.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
-
+	"strconv"
 	log "github.com/Sirupsen/logrus"
 	"github.com/infinityworksltd/prometheus-rancher-exporter/measure"
 	"github.com/prometheus/client_golang/prometheus"
@@ -69,9 +69,9 @@ func (e *Exporter) processMetrics(data *Data, endpoint string, hideSys bool, ch 
 			// Later used as a dimension in service metrics
 			stackRef = storeStackRef(x.ID, x.Name)
 
-			if err := e.setStackMetrics(x.Name, x.State, x.HealthState); err != nil {
+			if err := e.setStackMetrics(x.Name, x.State, x.HealthState, strconv.FormatBool(x.System)); err != nil {
 				log.Errorf("Error processing stack metrics: %s", err)
-				log.Errorf("Attempt Failed to set %s, %s, %s ", x.Name, x.State, x.HealthState)
+				log.Errorf("Attempt Failed to set %s, %s, %s, %s", x.Name, x.State, x.HealthState, x.System)
 				continue
 			}
 

--- a/metrics.go
+++ b/metrics.go
@@ -18,13 +18,13 @@ func addMetrics() map[string]*prometheus.GaugeVec {
 			Namespace: "rancher",
 			Name:      "stack_health_status",
 			Help:      "HealthState of defined stack as reported by Rancher",
-		}, []string{"name", "health_state"})
+		}, []string{"name", "health_state", "system"})
 	gaugeVecs["stacksState"] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "rancher",
 			Name:      "stack_state",
 			Help:      "State of defined stack as reported by Rancher",
-		}, []string{"name", "state"})
+		}, []string{"name", "state", "system"})
 
 	// Service Metrics
 	gaugeVecs["servicesScale"] = prometheus.NewGaugeVec(
@@ -108,21 +108,19 @@ func (e *Exporter) setServiceMetrics(name string, stack string, state string, he
 }
 
 // setStackMetrics - Logic to set the state of a system as a gauge metric
-func (e *Exporter) setStackMetrics(name string, state string, health string) error {
-
+func (e *Exporter) setStackMetrics(name string, state string, health string, system string) error {
 	for _, y := range healthStates {
 		if health == y {
-			e.gaugeVecs["stacksHealth"].With(prometheus.Labels{"name": name, "health_state": y}).Set(1)
+			e.gaugeVecs["stacksHealth"].With(prometheus.Labels{"name": name, "health_state": y, "system": system}).Set(1)
 		} else {
-			e.gaugeVecs["stacksHealth"].With(prometheus.Labels{"name": name, "health_state": y}).Set(0)
+			e.gaugeVecs["stacksHealth"].With(prometheus.Labels{"name": name, "health_state": y, "system": system}).Set(0)
 		}
 	}
-
 	for _, y := range stackStates {
 		if state == y {
-			e.gaugeVecs["stacksState"].With(prometheus.Labels{"name": name, "state": y}).Set(1)
+			e.gaugeVecs["stacksState"].With(prometheus.Labels{"name": name, "state": y, "system": system}).Set(1)
 		} else {
-			e.gaugeVecs["stacksState"].With(prometheus.Labels{"name": name, "state": y}).Set(0)
+			e.gaugeVecs["stacksState"].With(prometheus.Labels{"name": name, "state": y, "system": system}).Set(0)
 		}
 
 	}


### PR DESCRIPTION
Adding a system label for stack metrics makes it possible to do the difference between system stacks and other stacks in Prometheus.